### PR TITLE
Update RxJava version and make necessary changes

### DIFF
--- a/traceur/build.gradle
+++ b/traceur/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'java'
 
 dependencies {
-    compile 'io.reactivex.rxjava2:rxjava:2.0.7'
+    compile 'io.reactivex.rxjava2:rxjava:2.2.17'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:3.6.2'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 ext {
     bintrayRepo = 'maven'

--- a/traceur/src/main/java/com/tspoon/traceur/FlowableOnAssembly.java
+++ b/traceur/src/main/java/com/tspoon/traceur/FlowableOnAssembly.java
@@ -61,12 +61,12 @@ final class FlowableOnAssembly<T> extends Flowable<T> {
 
         @Override
         public void onNext(T t) {
-            actual.onNext(t);
+            downstream.onNext(t);
         }
 
         @Override
         public void onError(Throwable t) {
-            actual.onError(assembled.appendAndNotify(t));
+            downstream.onError(assembled.appendAndNotify(t));
         }
 
         @Override
@@ -98,17 +98,17 @@ final class FlowableOnAssembly<T> extends Flowable<T> {
 
         @Override
         public void onNext(T t) {
-            actual.onNext(t);
+            downstream.onNext(t);
         }
 
         @Override
         public boolean tryOnNext(T t) {
-            return actual.tryOnNext(t);
+            return downstream.tryOnNext(t);
         }
 
         @Override
         public void onError(Throwable t) {
-            actual.onError(assembled.appendAndNotify(t));
+            downstream.onError(assembled.appendAndNotify(t));
         }
 
         @Override

--- a/traceur/src/main/java/com/tspoon/traceur/ObservableOnAssembly.java
+++ b/traceur/src/main/java/com/tspoon/traceur/ObservableOnAssembly.java
@@ -54,17 +54,17 @@ final class ObservableOnAssembly<T> extends Observable<T> {
 
         @Override
         public void onNext(T t) {
-            actual.onNext(t);
+            downstream.onNext(t);
         }
 
         @Override
         public void onError(Throwable t) {
-            actual.onError(assembled.appendAndNotify(t));
+            downstream.onError(assembled.appendAndNotify(t));
         }
 
         @Override
         public int requestFusion(int mode) {
-            QueueDisposable<T> qs = this.qs;
+            QueueDisposable<T> qs = this.qd;
             if (qs != null) {
                 int m = qs.requestFusion(mode);
                 sourceMode = m;
@@ -75,7 +75,7 @@ final class ObservableOnAssembly<T> extends Observable<T> {
 
         @Override
         public T poll() throws Exception {
-            return qs.poll();
+            return qd.poll();
         }
     }
 }


### PR DESCRIPTION
Updated RxJava version from 2.0.7 to 2.2.17. Made necessary changes for the library to work with it. Also changed from Java 7 to Java 8 as a test was not compiling.